### PR TITLE
fix: edit validator labels for Telegram and Discord

### DIFF
--- a/pkg/templates/discord.go
+++ b/pkg/templates/discord.go
@@ -133,31 +133,31 @@ func (m *DiscordTemplateManager) SerializeEvent(event types.RenderEventItem) str
 		)
 	case events.ValidatorJailed:
 		return fmt.Sprintf(
-			"**❌ %s was jailed**%s",
+			"**❌ %s has been jailed**%s",
 			validatorLink,
 			notifiersSerialized,
 		)
 	case events.ValidatorUnjailed:
 		return fmt.Sprintf(
-			"**👌 %s was unjailed**%s",
+			"**👌 %s has been unjailed**%s",
 			validatorLink,
 			notifiersSerialized,
 		)
 	case events.ValidatorInactive:
 		return fmt.Sprintf(
-			"😔 **%s is now not in the active set**%s",
+			"😔 **%s has left the active set**%s",
 			validatorLink,
 			notifiersSerialized,
 		)
 	case events.ValidatorActive:
 		return fmt.Sprintf(
-			"✅ **%s is now in the active set**%s",
+			"✅ **%s has joined the active set**%s",
 			validatorLink,
 			notifiersSerialized,
 		)
 	case events.ValidatorTombstoned:
 		return fmt.Sprintf(
-			"**💀 %s was tombstoned**%s",
+			"**💀 %s has been tombstoned**%s",
 			validatorLink,
 			notifiersSerialized,
 		)

--- a/pkg/templates/telegram.go
+++ b/pkg/templates/telegram.go
@@ -126,31 +126,31 @@ func (m *TelegramTemplateManager) SerializeEvent(event types.RenderEventItem) st
 		)
 	case events.ValidatorJailed:
 		return fmt.Sprintf(
-			"<strong>❌ %s was jailed</strong>%s",
+			"<strong>❌ %s has been jailed</strong>%s",
 			m.SerializeLink(event.ValidatorLink),
 			notifiersSerialized,
 		)
 	case events.ValidatorUnjailed:
 		return fmt.Sprintf(
-			"<strong>👌 %s was unjailed</strong>%s",
+			"<strong>👌 %s has been unjailed</strong>%s",
 			m.SerializeLink(event.ValidatorLink),
 			notifiersSerialized,
 		)
 	case events.ValidatorInactive:
 		return fmt.Sprintf(
-			"😔 <strong>%s is now not in the active set</strong>%s",
+			"😔 <strong>%s has left the active set</strong>%s",
 			m.SerializeLink(event.ValidatorLink),
 			notifiersSerialized,
 		)
 	case events.ValidatorActive:
 		return fmt.Sprintf(
-			"✅ <strong>%s is now in the active set</strong>%s",
+			"✅ <strong>%s has joined the active set</strong>%s",
 			m.SerializeLink(event.ValidatorLink),
 			notifiersSerialized,
 		)
 	case events.ValidatorTombstoned:
 		return fmt.Sprintf(
-			"<strong>💀 %s was tombstoned</strong>%s",
+			"<strong>💀 %s has been tombstoned</strong>%s",
 			m.SerializeLink(event.ValidatorLink),
 			notifiersSerialized,
 		)


### PR DESCRIPTION
**fix**: labels

Edited validator labels when joining/leaving the active set or when being jailed/tombstoned